### PR TITLE
Bump ssh2-sftp-client to v9.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/lu-test",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/lu-test",
-      "version": "5.2.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/pubsub": "^3.3.0",
@@ -22,7 +22,7 @@
         "mocha-cakes-2": "^3.3.0",
         "nock": "^13.0.11",
         "sinon": "^15.0.0",
-        "ssh2-sftp-client": "^7.2.3",
+        "ssh2-sftp-client": "^9.1.0",
         "supertest": "^6.3.3"
       },
       "devDependencies": {
@@ -6087,13 +6087,13 @@
       }
     },
     "node_modules/ssh2-sftp-client": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-7.2.3.tgz",
-      "integrity": "sha512-Bmq4Uewu3e0XOwu5bnPbiS5KRQYv+dff5H6+85V4GZrPrt0Fkt1nUH+uXanyAkoNxUpzjnAPEEoLdOaBO9c3xw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-9.1.0.tgz",
+      "integrity": "sha512-Hzdr9OE6GxZjcmyM9tgBSIFVyrHAp9c6U2Y4yBkmYOHoQvZ7pIm27dmltvcmRfxcWiIcg8HBvG5iAikDf+ZuzQ==",
       "dependencies": {
         "concat-stream": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "ssh2": "^1.8.0"
+        "ssh2": "^1.12.0"
       },
       "engines": {
         "node": ">=10.24.1"
@@ -11445,13 +11445,13 @@
       }
     },
     "ssh2-sftp-client": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-7.2.3.tgz",
-      "integrity": "sha512-Bmq4Uewu3e0XOwu5bnPbiS5KRQYv+dff5H6+85V4GZrPrt0Fkt1nUH+uXanyAkoNxUpzjnAPEEoLdOaBO9c3xw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/ssh2-sftp-client/-/ssh2-sftp-client-9.1.0.tgz",
+      "integrity": "sha512-Hzdr9OE6GxZjcmyM9tgBSIFVyrHAp9c6U2Y4yBkmYOHoQvZ7pIm27dmltvcmRfxcWiIcg8HBvG5iAikDf+ZuzQ==",
       "requires": {
         "concat-stream": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "ssh2": "^1.8.0"
+        "ssh2": "^1.12.0"
       }
     },
     "statuses": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/lu-test",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Test helpers.",
   "main": "index.js",
   "engines": {
@@ -35,7 +35,7 @@
     "mocha-cakes-2": "^3.3.0",
     "nock": "^13.0.11",
     "sinon": "^15.0.0",
-    "ssh2-sftp-client": "^7.2.3",
+    "ssh2-sftp-client": "^9.1.0",
     "supertest": "^6.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- Requires that the client application also uses ssh2-sftp-client ^9.1.0