### PR TITLE
Allow skipping select sequences in `fake-pub-sub`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/lu-test",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/lu-test",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/pubsub": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/lu-test",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Test helpers.",
   "main": "index.js",
   "engines": {

--- a/test/feature/run-sequence-feature.js
+++ b/test/feature/run-sequence-feature.js
@@ -47,4 +47,35 @@ Feature("run-sequence feature", () => {
       response.message.should.eql("Sequence not processed, see log");
     });
   });
+
+  Scenario("run sequence skipping certain keys", () => {
+    let response;
+    When("running the sequence", async () => {
+      response = await runSequence(
+        app,
+        "sequence.trigger-other-sequence",
+        message,
+        { skipSequences: [ "sequence.some-sequence" ] }
+      );
+    });
+
+    Then("we should should have a processed sequence without the skipped step", () => {
+      response.should.eql({
+        topic: "some-topic",
+        message: {
+          id: "some-guid",
+          type: "something",
+          attributes: { name: "Someone" },
+          meta: {},
+          data: [
+            { type: "step1", id: "some-id" },
+            { type: "trigger", key: "sequence.some-sequence" },
+          ],
+        },
+        attributes: { key: "sequence.trigger-other-sequence.processed" },
+        deliveryAttempt: 1,
+        triggeredFlows: [ "sequence.trigger-other-sequence" ],
+      });
+    });
+  });
 });

--- a/test/helpers/run-sequence.js
+++ b/test/helpers/run-sequence.js
@@ -1,9 +1,9 @@
 import { enablePublish, triggerMessage, recordedMessages, reset } from "./fake-pub-sub.js";
 
-async function runSequence(app, sequenceName, message, throwOnError = true) {
-  enablePublish(app);
+async function runSequence(app, sequenceName, message, opts = {}) {
+  enablePublish(app, opts);
   try {
-    await triggerMessage(app, message, { key: sequenceName }, { throwOnError });
+    await triggerMessage(app, message, { key: sequenceName });
     const last = recordedMessages()[recordedMessages().length - 1];
     if (last?.attributes?.key?.split(".").pop() !== "processed") {
       throw new Error("Sequence not processed, see log");


### PR DESCRIPTION
Allow disabling running other sequences, by providing a list `skipSequences` to `runSequence`.

These triggers are considered side effects and can therefore be excluded in sequence tests.

So an example from payment-worker would be, in `payment-worker/test/feature/handle-processed-wire-transfer/sequence-feature.js`:

```js
    When("a trigger message for a apply wire transfer payments", async () => {
      message = await runSequence(
        app,
        "trigger.sub-sequence.handle-processed-wire-transfer",
        source,
        { skipSequences: [ "sequence.create-applied-zuora-payment" ] }
      );
    });
```