### PR TITLE
return size: 0 as a string

### DIFF
--- a/test/feature/fake-gcs-feature.js
+++ b/test/feature/fake-gcs-feature.js
@@ -516,7 +516,7 @@ Feature("fake-gcs feature", () => {
           contentEncoding: "utf-8",
           contentType: "text/csv",
           name: "file_1.csv",
-          size: 0,
+          size: "0",
         },
       ]);
     });

--- a/test/helpers/fake-gcs.js
+++ b/test/helpers/fake-gcs.js
@@ -49,7 +49,9 @@ function mockFile(path, opts) {
             ? [
               {
                 name: key.split("/").pop(),
-                size: file.content ? new Blob([ file.content ]).size : 0,
+                // when logging the metadata size of an empty file, the gcs lib returned 0 as a string
+                // we do not know how it behaves with other values
+                size: file.content ? new Blob([ file.content ]).size : "0",
                 contentEncoding: file.encoding,
                 contentType: contentType(key),
               },


### PR DESCRIPTION
The GCS lib returns size 0 as a string, so we'll need to change this in our fake-gcs