### PR TITLE
Couple of fixes in fake cloud tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/lu-test",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/lu-test",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/pubsub": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/lu-test",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Test helpers.",
   "main": "index.js",
   "engines": {

--- a/test/feature/fake-cloud-tasks-feature.js
+++ b/test/feature/fake-cloud-tasks-feature.js
@@ -44,6 +44,7 @@ Feature("fake-cloud-task feature", () => {
       response = await cloudTask.createTask({
         parent: config.cloudTasks.queue,
         task: {
+          name: "test-task",
           httpRequest: {
             url: `${config.cloudTasks.selfUrl}/foo/bar`,
             httpMethod: "post",
@@ -64,6 +65,7 @@ Feature("fake-cloud-task feature", () => {
 
     And("we should have recorded the message", () => {
       fakeCloudTasks.recordedMessages()[0].should.eql({
+        taskName: "test-task",
         queue: config.cloudTasks.queue,
         httpMethod: "post",
         message: { type: "something", id: "some-id" },
@@ -99,6 +101,7 @@ Feature("fake-cloud-task feature", () => {
       response = await cloudTask.createTask({
         parent: config.cloudTasks.queue,
         task: {
+          name: "test-task",
           httpRequest: {
             url: `${config.cloudTasks.selfUrl}/foo/bar`,
             httpMethod: "get",
@@ -118,6 +121,7 @@ Feature("fake-cloud-task feature", () => {
 
     And("we should have recorded the message", () => {
       fakeCloudTasks.recordedMessages()[0].should.eql({
+        taskName: "test-task",
         queue: config.cloudTasks.queue,
         httpMethod: "get",
         url: "/foo/bar",
@@ -163,6 +167,7 @@ Feature("cloud tasks run-sequence feature", () => {
           cloudTask.createTask({
             parent: config.cloudTasks.queue,
             task: {
+              name: `test-${task}`,
               httpRequest: {
                 url: `${config.cloudTasks.selfUrl}/foo/bar`,
                 httpMethod: "post",
@@ -191,6 +196,7 @@ Feature("cloud tasks run-sequence feature", () => {
           queue: config.cloudTasks.queue,
           url: "/foo/bar",
           correlationId: "some-epic-id",
+          taskName: "test-task1",
         },
         {
           message: { task: "task2" },
@@ -199,6 +205,7 @@ Feature("cloud tasks run-sequence feature", () => {
           queue: config.cloudTasks.queue,
           url: "/foo/bar",
           correlationId: "some-epic-id",
+          taskName: "test-task2",
         },
       ]);
     });

--- a/test/helpers/fake-cloud-tasks.js
+++ b/test/helpers/fake-cloud-tasks.js
@@ -42,7 +42,7 @@ export async function runSequence(broker, url, body, headers = {}) {
     await processMessages();
 
     const last = messages.slice(-1)[0];
-    const triggeredFlows = [ ...new Set(recordedMessages().map((o) => o.url.split("/").slice(0, 2).join("."))) ];
+    const triggeredFlows = [ ...new Set(recordedMessages().map((o) => o.url.split("/").slice(-3, -1).join("."))) ];
     return {
       ...last,
       triggeredFlows,

--- a/test/helpers/fake-cloud-tasks.js
+++ b/test/helpers/fake-cloud-tasks.js
@@ -65,12 +65,15 @@ export async function processMessages() {
 
 async function handleMessage({
   parent,
-  task: { httpRequest: { httpMethod, headers, url, body } },
-  taskName,
+  task: {
+    name = "test-task",
+    httpRequest: { httpMethod, headers, url, body },
+  },
 }) {
   const relativeUrl = url.replace(config.cloudTasks.selfUrl, "");
   const queueName = parent.split("/").pop();
   const bodyObject = body ? JSON.parse(body.toString()) : undefined;
+  const taskName = name;
 
   const cloudRunHeaders = {
     "X-CloudTasks-QueueName": queueName,
@@ -82,6 +85,7 @@ async function handleMessage({
 
   messages.push({
     queue: parent,
+    taskName,
     httpMethod,
     headers,
     url: relativeUrl,


### PR DESCRIPTION
- Make `triggeredFlows` work with longer URLs. This is used quite a bit in `distribution-worker`.
- Handle task names correctly and return it in `recordedMessages`. This is used to test some name functionality in the `b0rker`.