### PR TITLE
Make runSequence throw an error if some task fails

### DIFF
--- a/test/helpers/fake-cloud-tasks.js
+++ b/test/helpers/fake-cloud-tasks.js
@@ -104,6 +104,10 @@ async function handleMessage({
     error: response.error,
     url: response.req.path,
   });
+  if (response.statusCode !== 200) {
+    const usefulStuff = { statusCode: response.statusCode, body: response.body };
+    throw new Error(`Failed to process message, check the logs: ${JSON.stringify(usefulStuff)}`);
+  }
 }
 
 export function reset() {


### PR DESCRIPTION
When writing new tests, sometimes we forget to mock things, and sometimes a function will fail. The existing `runSequence` in `fake-cloud-tasks` just silently returns with whatever has processed up to then which makes debugging somewhat difficult (and sometimes very confusing).

This PR makes `runSequence` in `fake-cloud-tasks` throw an error if anything bad happens during task processing