### PR TITLE
Default to not trigger any `sequence` from the main when testing with `runSequence`

### DIFF
--- a/test/feature/fake-cloud-tasks-feature.js
+++ b/test/feature/fake-cloud-tasks-feature.js
@@ -254,10 +254,12 @@ Feature("cloud tasks run-sequence feature", () => {
         {
           queue: config.cloudTasks.queue,
           url: "/v2/sequence/task1/testing-skipped",
+          message: { task: "task1" },
         },
         {
           queue: config.cloudTasks.queue,
           url: "/v2/sequence/task2/testing-skipped",
+          message: { task: "task2" },
         },
       ]);
     });
@@ -266,6 +268,21 @@ Feature("cloud tasks run-sequence feature", () => {
       result.messageHandlerResponses
         .map((response) => response.body)
         .should.eql([ "Triggered sequence skipped", "Triggered sequence skipped" ]);
+    });
+
+    And("the sequences should have been triggered with the expected messages", () => {
+      result.triggeredSequences.should.eql([
+        {
+          queue: "projects/project-id/locations/location/queues/foo-queue",
+          url: "/v2/sequence/task1/testing-skipped",
+          message: { task: "task1" },
+        },
+        {
+          queue: "projects/project-id/locations/location/queues/foo-queue",
+          url: "/v2/sequence/task2/testing-skipped",
+          message: { task: "task2" },
+        },
+      ]);
     });
   });
 
@@ -310,6 +327,29 @@ Feature("cloud tasks run-sequence feature", () => {
       result.messageHandlerResponses
         .map((response) => response.body)
         .should.eql([ { task: "task1" }, { task: "task2" } ]);
+    });
+
+    And("the sequences should have been triggered with the expected messages", () => {
+      result.triggeredSequences.should.eql([
+        {
+          queue: "projects/project-id/locations/location/queues/foo-queue",
+          taskName: "test-task1",
+          httpMethod: "post",
+          headers: { correlationId: "some-epic-id" },
+          url: "/v2/sequence/task1",
+          message: { task: "task1" },
+          correlationId: "some-epic-id",
+        },
+        {
+          queue: "projects/project-id/locations/location/queues/foo-queue",
+          taskName: "test-task2",
+          httpMethod: "post",
+          headers: { correlationId: "some-epic-id" },
+          url: "/v2/sequence/task2",
+          message: { task: "task2" },
+          correlationId: "some-epic-id",
+        },
+      ]);
     });
   });
 

--- a/test/feature/fake-cloud-tasks-feature.js
+++ b/test/feature/fake-cloud-tasks-feature.js
@@ -249,7 +249,7 @@ Feature("cloud tasks run-sequence feature", () => {
       result = await fakeCloudTasks.runSequence(app, "/sequence");
     });
 
-    Then("two sequences should have been skipped", () => {
+    Then("two sequences should have been not have been tested", () => {
       result.messages.should.eql([
         {
           queue: config.cloudTasks.queue,
@@ -264,14 +264,14 @@ Feature("cloud tasks run-sequence feature", () => {
       ]);
     });
 
-    And("the sequences should have been skipped", () => {
+    And("the sequences should not have been tested", () => {
       result.messageHandlerResponses
         .map((response) => response.body)
-        .should.eql([ "Triggered sequence skipped", "Triggered sequence skipped" ]);
+        .should.eql([ "Triggered sequence not tested", "Triggered sequence not tested" ]);
     });
 
     And("the sequences should have been triggered with the expected messages", () => {
-      result.triggeredSequences.should.eql([
+      result.notTestedSequences.should.eql([
         {
           queue: "projects/project-id/locations/location/queues/foo-queue",
           url: "/v2/sequence/task1/testing-skipped",
@@ -330,7 +330,7 @@ Feature("cloud tasks run-sequence feature", () => {
     });
 
     And("the sequences should have been triggered with the expected messages", () => {
-      result.triggeredSequences.should.eql([
+      result.messages.should.eql([
         {
           queue: "projects/project-id/locations/location/queues/foo-queue",
           taskName: "test-task1",

--- a/test/feature/fake-cloud-tasks-feature.js
+++ b/test/feature/fake-cloud-tasks-feature.js
@@ -153,6 +153,25 @@ Feature("fake-cloud-task feature", () => {
   });
 });
 
+const sequenceTriggeringSequence = (req, res) => {
+  const cloudTask = new CloudTasksClient();
+  [ "task1", "task2" ].forEach((task) => {
+    cloudTask.createTask({
+      parent: config.cloudTasks.queue,
+      task: {
+        name: `test-${task}`,
+        httpRequest: {
+          url: `${config.cloudTasks.selfUrl}/v2/sequence/${task}`,
+          httpMethod: "post",
+          headers: { correlationId: "some-epic-id" },
+          body: Buffer.from(JSON.stringify({ task })),
+        },
+      },
+    });
+  });
+  res.status(200).json({ status: "ok" }).send();
+};
+
 Feature("cloud tasks run-sequence feature", () => {
   beforeEachScenario(fakeCloudTasks.reset);
 
@@ -204,6 +223,83 @@ Feature("cloud tasks run-sequence feature", () => {
           httpMethod: "post",
           queue: config.cloudTasks.queue,
           url: "/foo/bar",
+          correlationId: "some-epic-id",
+          taskName: "test-task2",
+        },
+      ]);
+    });
+
+    And("the messages should have been processed", () => {
+      result.messageHandlerResponses
+        .map((response) => response.body)
+        .should.eql([ { task: "task1" }, { task: "task2" } ]);
+    });
+  });
+
+  Scenario("successfully run a sequence, skipping the triggering of a sequence", () => {
+    let app;
+    Given("a broker", () => {
+      app = express();
+      app.use(express.json());
+      app.post("/sequence", sequenceTriggeringSequence);
+    });
+
+    let result;
+    When("running the sequence", async () => {
+      result = await fakeCloudTasks.runSequence(app, "/sequence");
+    });
+
+    Then("two sequences should have been skipped", () => {
+      result.messages.should.eql([
+        {
+          queue: config.cloudTasks.queue,
+          url: "/v2/sequence/task1/testing-skipped",
+        },
+        {
+          queue: config.cloudTasks.queue,
+          url: "/v2/sequence/task2/testing-skipped",
+        },
+      ]);
+    });
+
+    And("the sequences should have been skipped", () => {
+      result.messageHandlerResponses
+        .map((response) => response.body)
+        .should.eql([ "Triggered sequence skipped", "Triggered sequence skipped" ]);
+    });
+  });
+
+  Scenario("successfully run a sequence, and trigger another sequence from it", () => {
+    let app;
+    Given("a broker", () => {
+      app = express();
+      app.use(express.json());
+      app.post("/sequence", sequenceTriggeringSequence);
+      app.post("/v2/sequence/:task", (req, res) => res.status(200).json({ task: req.params.task }).send());
+    });
+
+    let result;
+    When("running the sequence", async () => {
+      result = await fakeCloudTasks.runSequence(app, "/sequence", undefined, {}, false);
+    });
+
+    Then("two messages should have been published", () => {
+      result.messages.should.eql([
+        {
+          message: { task: "task1" },
+          headers: { correlationId: "some-epic-id" },
+          httpMethod: "post",
+          queue: config.cloudTasks.queue,
+          url: "/v2/sequence/task1",
+          correlationId: "some-epic-id",
+          taskName: "test-task1",
+        },
+        {
+          message: { task: "task2" },
+          headers: { correlationId: "some-epic-id" },
+          httpMethod: "post",
+          queue: config.cloudTasks.queue,
+          url: "/v2/sequence/task2",
           correlationId: "some-epic-id",
           taskName: "test-task2",
         },

--- a/test/helpers/fake-cloud-tasks.js
+++ b/test/helpers/fake-cloud-tasks.js
@@ -46,11 +46,11 @@ export async function runSequence(broker, url, body, headers = {}, skipSequenceT
     const last = messages.slice(-1)[0];
     const triggeredFlows = [ ...new Set(recordedMessages().map((o) => o.url.split("/").slice(-3, -1).join("."))) ];
 
-    const triggeredSequences = recordedMessages().filter((o) => o.url.match(triggerSequenceRegEx) || o.url.split("/").pop() === "testing-skipped");
+    const notTestedSequences = recordedMessages().filter((o) => o.url.split("/").pop() === "testing-skipped");
     return {
       ...last,
       triggeredFlows,
-      triggeredSequences,
+      notTestedSequences,
       firstResponse,
       messages: [ ...recordedMessages() ],
       messageHandlerResponses: [ ...recordedMessageHandlerResponses() ],
@@ -83,7 +83,7 @@ async function handleMessage(
 
   if (skipSequenceTriggers && relativeUrl.match(triggerSequenceRegEx)) {
     messages.push({ queue: parent, url: `${relativeUrl}/testing-skipped`, ...(bodyObject && { message: bodyObject }) });
-    messageHandlerResponses.push({ statusCode: 200, body: "Triggered sequence skipped", url: relativeUrl });
+    messageHandlerResponses.push({ statusCode: 200, body: "Triggered sequence not tested", url: relativeUrl });
     return;
   }
 


### PR DESCRIPTION
Most often when we test a whole `sequence` with `runSequence`, we just need to check that the main `sequence` works ok. If that `sequence` triggers another `sequence`, we don't often need to actually test that the triggered `sequence` works - that is in that sequence's sequence-feature test.

This PR defaults to not run any triggered `sequence` from the main `sequence` in `runSequence`.  It is still possible to test all triggered sequences in the main sequence-feature test by simply passing `false` as the final parameter in `runSequence`.

`runSequence` now also returns an array of `sequence`s that were not tested (`notTestedSequences`) including the message that was used to trigger them etc... This will allow for checking that we trigger the `sequence` with the expected source (much like we do with `fakeApi`'s `hasExpectedBody()` function).